### PR TITLE
Move `--hooks-dir` to global arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -2540,9 +2540,10 @@ The command `nft` needs to be installed on the host.
    ```
 6. Run curl command to dowload http://podman.io
    ```
-   podman run \
-       --rm \
+   podman \
        --hooks-dir ~/hooks.d \
+       run \
+       --rm \
        --annotation myannotation=yes \
        docker.io/library/fedora \
        bash -c "curl -sS --connect-timeout 3 http://podman.io | head -1"
@@ -2553,9 +2554,10 @@ The command `nft` needs to be installed on the host.
    ```
 7. Run curl command to dowload https://podman.io
    ```
-   podman run \
-       --rm \
+   podman \
        --hooks-dir ~/hooks.d \
+       run \
+       --rm \
        --annotation myannotation=yes \
        docker.io/library/fedora \
        bash -c "curl -sS --connect-timeout 3 https://podman.io | head -1"


### PR DESCRIPTION
As can be seen by the following commands, the command-line option `--hooks-dir` belongs to the global arguments.

```
$ podman --help | grep -- --hooks-dir
      --hooks-dir stringArray       Set the OCI hooks directory path (may be set multiple times) (default [/usr/share/containers/oci/hooks.d])
$ podman run --help | grep -- --hooks-dir
$
```

In other words, the option is described here

https://docs.podman.io/en/latest/markdown/podman.1.html#hooks-dir-path

but not here

https://docs.podman.io/en/latest/markdown/podman-run.1.html

__Side note:__

The command-line parsing in Podman actually allows both

```
podman run --hooks-dir /some/dir ...
```

```
podman --hooks-dir /some/dir run ...
```